### PR TITLE
directories: expand ~ in directory paths with expanduser()

### DIFF
--- a/meeting_notes/app.py
+++ b/meeting_notes/app.py
@@ -684,7 +684,7 @@ class MeetingNotesApp(App):
             ai_model=self.config.ai_model,
             api_key=api_key
         )
-        self.notes_dir = Path(self.config.notes_dir)
+        self.notes_dir = Path(self.config.notes_dir).expanduser()
         self.notes_dir.mkdir(exist_ok=True)
         self.is_recording = False
         self.timer_interval = None
@@ -1467,7 +1467,7 @@ class MeetingNotesApp(App):
                                 break
                 
                 if transcript_filename:
-                    transcript_path = Path(self.config.transcripts_dir) / transcript_filename
+                    transcript_path = Path(self.config.transcripts_dir).expanduser() / transcript_filename
                     
                     if transcript_path.exists():
                         self.push_screen(TranscriptViewer(transcript_path))
@@ -1525,7 +1525,7 @@ class MeetingNotesApp(App):
                 ai_model=self.config.ai_model,
                 api_key=api_key
             )
-            self.notes_dir = Path(self.config.notes_dir)
+            self.notes_dir = Path(self.config.notes_dir).expanduser()
             self.notes_dir.mkdir(exist_ok=True)
             
             # Reinitialize recorder if not currently recording

--- a/meeting_notes/note_maker.py
+++ b/meeting_notes/note_maker.py
@@ -47,8 +47,8 @@ class NoteMaker:
             api_key: API key for cloud provider (or use env var)
         """
         logger.info(f"Initializing NoteMaker (output_dir: {output_dir}, transcripts_dir: {transcripts_dir}, ai_provider: {ai_provider}, ai_model: {ai_model})")
-        self.output_dir = Path(output_dir)
-        self.transcripts_dir = Path(transcripts_dir)
+        self.output_dir = Path(output_dir).expanduser()
+        self.transcripts_dir = Path(transcripts_dir).expanduser()
         self.output_dir.mkdir(exist_ok=True)
         self.transcripts_dir.mkdir(exist_ok=True)
         self.ai_provider = ai_provider

--- a/meeting_notes/recorder.py
+++ b/meeting_notes/recorder.py
@@ -25,7 +25,7 @@ class AudioRecorder:
             mode: Recording mode - "mic", "system", or "combined" (default)
             dev_mode: If True, preserve temporary files for debugging (default: False)
         """
-        self.output_dir = Path(output_dir)
+        self.output_dir = Path(output_dir).expanduser()
         self.output_dir.mkdir(exist_ok=True)
         self.process: Optional[subprocess.Popen] = None
         self.current_file: Optional[Path] = None


### PR DESCRIPTION
Not everywhere was expanding `~/` paths which caused various `EEXIST` errors to crop up in usage. Expand user paths everywhere.