### PR TITLE
fork improvements + CI: bug fixes from community forks, tests, GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel any in-progress run on the same ref when a new commit is pushed.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint + tests (Python 3.12)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install lightweight test deps
+        # Deliberately avoiding the [all] extra: that pulls openai-whisper
+        # which transitively installs torch (~1GB) and explodes CI time.
+        # The fast tests (config, paths, retention, summarizers) only need
+        # the cloud SDK clients + pyyaml + the dev tools. The Textual smoke
+        # tests are kept locally only — see tests/test_textual_smoke.py and
+        # the Testing section in the README.
+        run: |
+          python -m pip install --upgrade pip
+          pip install \
+            pyyaml \
+            openai \
+            anthropic \
+            openrouter \
+            pytest \
+            pytest-asyncio \
+            ruff
+
+      - name: Lint (ruff)
+        run: ruff check meeting_notes/ tests/
+
+      - name: Test (pytest, fast tests only)
+        # Explicitly listing the test files keeps CI green even if someone
+        # later adds a new test file with heavy dependencies.
+        run: |
+          pytest -v \
+            tests/test_config.py \
+            tests/test_paths_and_fallbacks.py \
+            tests/test_recording_retention.py \
+            tests/test_summarizers.py

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ config.yml
 # Docs
 docs/
 
-# Tests (outdated)
-tests/
+# Pytest cache
+.pytest_cache/
+.ruff_cache/
 
 # OpenCode
 .opencode/plans/

--- a/README.md
+++ b/README.md
@@ -354,3 +354,19 @@ This is a personal project but suggestions and contributions are welcome!
 1. Open an issue for bugs or feature requests
 2. Check the roadmap above for planned features
 3. Submit PRs with clear descriptions
+
+### Running tests
+
+```bash
+# Lightweight tests (matches CI — no whisper/torch needed)
+pip install pytest pytest-asyncio ruff openai anthropic openrouter pyyaml
+pytest tests/test_config.py tests/test_paths_and_fallbacks.py \
+       tests/test_recording_retention.py tests/test_summarizers.py
+ruff check meeting_notes/ tests/
+
+# Full suite (also runs Textual headless smoke tests; needs the full env)
+pip install -e ".[all,dev]"
+pytest
+```
+
+CI (`.github/workflows/ci.yml`) runs the lightweight subset on every PR.

--- a/meeting_notes/ai_summarizer.py
+++ b/meeting_notes/ai_summarizer.py
@@ -302,14 +302,14 @@ class AnthropicSummarizer(BaseSummarizer):
     
     MODELS = {
         "haiku": {
-            "id": "claude-3-5-haiku-20241022",
-            "name": "Claude 3.5 Haiku",
+            "id": "claude-haiku-4-5-20251001",
+            "name": "Claude Haiku 4.5",
             "cost_per_1k_input": 0.0008,
             "cost_per_1k_output": 0.004,
         },
         "sonnet": {
-            "id": "claude-3-5-sonnet-20241022",
-            "name": "Claude 3.5 Sonnet",
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
             "cost_per_1k_input": 0.003,
             "cost_per_1k_output": 0.015,
         }

--- a/meeting_notes/app.py
+++ b/meeting_notes/app.py
@@ -7,7 +7,7 @@ import subprocess
 import os
 import multiprocessing.resource_tracker
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 from textual.app import App, ComposeResult
@@ -76,14 +76,32 @@ class RecordingView(Container):
     def on_key(self, event) -> None:
         """Handle key events for the recording view."""
         if event.key == "escape":
-            # Unfocus the title input
+            # Unfocus the title input or notes textarea so global key
+            # bindings (like 's' to stop) work again without tabbing away.
             try:
-                title_input = self.query_one("#meeting-title-input", Input)
-                if title_input.has_focus:
+                if self._has_focused_input():
                     self.screen.set_focus(None)
                     event.prevent_default()
             except Exception:
-                pass  # Input not found or not mounted
+                pass  # Inputs not found or not mounted
+        elif event.key == "s" and not self._has_focused_input():
+            # Allow 's' to stop the recording even when the recording view
+            # is focused but no input widget within it is. Without this,
+            # the user has to manually tab away from inputs first.
+            event.prevent_default()
+            self.app.action_stop_recording()
+        elif event.key == "x" and not self._has_focused_input():
+            event.prevent_default()
+            self.app.action_cancel_recording()
+
+    def _has_focused_input(self) -> bool:
+        """Check if any text input widget within this view has focus."""
+        try:
+            title_input = self.query_one("#meeting-title-input", Input)
+            notes_input = self.query_one("#user-notes-input", TextArea)
+            return title_input.has_focus or notes_input.has_focus
+        except Exception:
+            return False
 
 
 class MeetingListItem(ListItem):
@@ -686,12 +704,39 @@ class MeetingNotesApp(App):
             api_key=api_key
         )
         self.notes_dir = Path(self.config.notes_dir).expanduser()
-        self.notes_dir.mkdir(exist_ok=True)
+        self.notes_dir.mkdir(parents=True, exist_ok=True)
         self.is_recording = False
         self.timer_interval = None
         self.recording_start_time = None
         self.all_note_paths = []  # Store all note paths for filtering
-        
+
+        # Clean up old recordings on startup
+        self._cleanup_old_recordings()
+
+    def _cleanup_old_recordings(self) -> None:
+        """Delete .wav recordings older than recording_retention_days.
+
+        No-op if retention_days <= 0 or the recordings dir doesn't exist.
+        Errors are logged but not raised — cleanup is best-effort.
+        """
+        retention_days = getattr(self.config, "recording_retention_days", 0)
+        if retention_days <= 0:
+            return
+        recordings_dir = Path(self.config.recordings_dir).expanduser()
+        if not recordings_dir.is_dir():
+            return
+        cutoff = datetime.now() - timedelta(days=retention_days)
+        for wav_file in recordings_dir.glob("*.wav"):
+            try:
+                if datetime.fromtimestamp(wav_file.stat().st_mtime) < cutoff:
+                    logger.info(
+                        f"Removing old recording: {wav_file.name} "
+                        f"(older than {retention_days} days)"
+                    )
+                    wav_file.unlink()
+            except Exception as e:
+                logger.warning(f"Failed to remove {wav_file.name}: {e}")
+
     def compose(self) -> ComposeResult:
         """Build the UI."""
         # Main content area
@@ -1483,6 +1528,12 @@ class MeetingNotesApp(App):
         """View transcript for the selected meeting."""
         viewer = self.query_one("#note-viewer", NoteViewer)
         if viewer.current_note:
+            # Guard against the underlying note file having been deleted
+            # since it was loaded (e.g. cleaned up externally) — otherwise
+            # the open() below crashes with FileNotFoundError.
+            if not Path(viewer.current_note).exists():
+                self.notify("Note file no longer exists", severity="warning")
+                return
             try:
                 # Read note to get transcript_file from frontmatter
                 with open(viewer.current_note, 'r') as f:
@@ -1559,7 +1610,7 @@ class MeetingNotesApp(App):
                 api_key=api_key
             )
             self.notes_dir = Path(self.config.notes_dir).expanduser()
-            self.notes_dir.mkdir(exist_ok=True)
+            self.notes_dir.mkdir(parents=True, exist_ok=True)
             
             # Reinitialize recorder if not currently recording
             if not self.is_recording:
@@ -1584,6 +1635,17 @@ def run(dev_mode: bool = False):
     # resource_tracker._launch().
     try:
         multiprocessing.resource_tracker.ensure_running()
+    except Exception:
+        pass  # Non-critical, best effort
+
+    # Belt-and-braces: tqdm lazily creates a multiprocessing.RLock the first
+    # time it is used, which on Python 3.14 also triggers the same
+    # fork_exec/fds_to_keep validation against a now-closed stderr. Force
+    # tqdm's lock to be created here while stderr is still valid; tqdm caches
+    # it at the class level so whisper's later progress bars reuse it.
+    try:
+        import tqdm
+        tqdm.tqdm.get_lock()
     except Exception:
         pass  # Non-critical, best effort
 

--- a/meeting_notes/config.py
+++ b/meeting_notes/config.py
@@ -34,6 +34,7 @@ class AppConfig:
     editor: str = "nvim"
     terminal_file_browser: str = ""  # Terminal file browser (ranger, vidir, nnn, lf, vifm, yazi, etc.)
     recording_mode: str = "combined"
+    recording_retention_days: int = 30  # Auto-delete .wav files older than this on startup (0 to disable)
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary."""

--- a/meeting_notes/note_maker.py
+++ b/meeting_notes/note_maker.py
@@ -49,8 +49,8 @@ class NoteMaker:
         logger.info(f"Initializing NoteMaker (output_dir: {output_dir}, transcripts_dir: {transcripts_dir}, ai_provider: {ai_provider}, ai_model: {ai_model})")
         self.output_dir = Path(output_dir).expanduser()
         self.transcripts_dir = Path(transcripts_dir).expanduser()
-        self.output_dir.mkdir(exist_ok=True)
-        self.transcripts_dir.mkdir(exist_ok=True)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.transcripts_dir.mkdir(parents=True, exist_ok=True)
         self.ai_provider = ai_provider
         self.summarizer: Optional[Any] = None
         
@@ -94,7 +94,9 @@ class NoteMaker:
             else:
                 try:
                     from .summarizer import OllamaSummarizer  # type: ignore
-                    self.summarizer = OllamaSummarizer(model=ai_model)
+                    # Defensive fallback: empty model name reaches
+                    # `ollama run "" <prompt>` and errors with "model is required".
+                    self.summarizer = OllamaSummarizer(model=ai_model or "llama3.2:3b")
                     logger.info(f"AI summarization enabled (Local Ollama: {ai_model})")
                     print(f"AI summarization enabled (Local Ollama: {ai_model})")
                 except Exception as e:

--- a/meeting_notes/recorder.py
+++ b/meeting_notes/recorder.py
@@ -26,7 +26,7 @@ class AudioRecorder:
             dev_mode: If True, preserve temporary files for debugging (default: False)
         """
         self.output_dir = Path(output_dir).expanduser()
-        self.output_dir.mkdir(exist_ok=True)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
         self.process: Optional[subprocess.Popen] = None
         self.current_file: Optional[Path] = None
         self.mode = mode  # "mic", "system", or "combined" (default)

--- a/meeting_notes/settings.py
+++ b/meeting_notes/settings.py
@@ -450,8 +450,8 @@ class SettingsScreen(Screen):
         current_model = self.config.get("ai_model", "haiku")
         
         models = [
-            ("haiku", "Claude 3.5 Haiku", "~$0.005/meeting - Fast & affordable ⭐"),
-            ("sonnet", "Claude 3.5 Sonnet", "~$0.020/meeting - Best quality"),
+            ("haiku", "Claude Haiku 4.5", "~$0.005/meeting - Fast & affordable ⭐"),
+            ("sonnet", "Claude Sonnet 4.6", "~$0.020/meeting - Best quality"),
         ]
         
         for model_id, model_name, model_desc in models:
@@ -527,7 +527,9 @@ class SettingsScreen(Screen):
                 widgets.append(Button("Install a Model", variant="warning", id="install-model-button"))
             else:
                 # Show installed models with current selection
-                current = self.config.get("ollama_model", "llama3.2:3b")
+                # `or` fallback handles empty-string config values, which
+                # dict.get's default does not.
+                current = self.config.get("ollama_model") or "llama3.2:3b"
                 
                 for model in installed:
                     is_current = model.name == current
@@ -630,7 +632,10 @@ class SettingsScreen(Screen):
                 elif event.button.provider_id == "openrouter":
                     self.config["ai_model"] = "balanced"
                 elif event.button.provider_id == "local":
-                    self.config["ai_model"] = self.config.get("ollama_model", "llama3.2:3b")
+                    # `or` fallback so an empty-string ollama_model still
+                    # produces a runnable default (dict.get only fills in the
+                    # default when the key is missing entirely).
+                    self.config["ai_model"] = self.config.get("ollama_model") or "llama3.2:3b"
                 await self.refresh_content()
         
         # AI model selection (for cloud providers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,34 @@ all = [
     "anthropic>=0.18.0",
     "openrouter>=0.1.0",
 ]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "ruff>=0.4",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+extend-exclude = ["venv", "notes", "transcripts", "recordings"]
+
+[tool.ruff.lint]
+# Conservative ruleset: real bugs and unused code, no style nitpicks.
+# `meeting_notes/` is not new code, so we don't want to fight existing style.
+select = ["E9", "F", "B"]
+ignore = [
+    "F401",  # imported but unused — Textual modules import widgets defensively
+    "F403",  # star imports — ditto
+    "F841",  # local variable assigned but never used — common in TUI handlers
+    "F541",  # f-string without placeholders — pre-existing, harmless
+    "B008",  # function call in default argument — used in some Textual patterns
+    "B904",  # raise ... from err — pre-existing, would change tracebacks visibly
+    "B005",  # strip with multi-character — pre-existing, single occurrence, low risk
+]
 
 [project.scripts]
 meeting-notes = "meeting_notes.app:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
+# Pinned dev install (everything). For packaging/optional extras see pyproject.toml.
+# Core
 textual>=0.50.0
 openai-whisper>=20231117
 pyyaml>=6.0
-openrouter>=0.1.0
+
+# Cloud AI providers (optional in pyproject.toml, required here for the bundled setup scripts)
 openai>=1.0.0
 anthropic>=0.18.0
+openrouter>=0.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest fixtures and config."""
+import os
+import sys
+from pathlib import Path
+
+# Ensure repo root is importable so `import meeting_notes...` works
+# regardless of how pytest is invoked.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Scrub real API keys from the environment so tests can't accidentally
+# make real network calls (and so individual tests can monkeypatch them
+# back without interference). Tests that need a key should provide a
+# fake one explicitly via monkeypatch.setenv.
+for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"):
+    os.environ.pop(key, None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+"""Tests for AppConfig: defaults, serialisation, validation."""
+from meeting_notes.config import AppConfig, validate_config
+
+
+def test_default_recording_retention_days():
+    """The retention field should default to 30 days (jmalobicky fork)."""
+    cfg = AppConfig()
+    assert cfg.recording_retention_days == 30
+
+
+def test_recording_retention_days_can_be_disabled():
+    """Setting retention to 0 disables cleanup."""
+    cfg = AppConfig.from_dict({"recording_retention_days": 0})
+    assert cfg.recording_retention_days == 0
+
+
+def test_recording_retention_roundtrips_through_dict():
+    """to_dict / from_dict should preserve the new field."""
+    cfg = AppConfig.from_dict({"recording_retention_days": 7})
+    assert cfg.recording_retention_days == 7
+    d = cfg.to_dict()
+    assert d["recording_retention_days"] == 7
+    cfg2 = AppConfig.from_dict(d)
+    assert cfg2.recording_retention_days == 7
+
+
+def test_terminal_file_browser_defaults_to_empty():
+    """The terminal_file_browser field (mathstuf #8) defaults to empty string."""
+    cfg = AppConfig()
+    assert cfg.terminal_file_browser == ""
+
+
+def test_unknown_keys_in_from_dict_are_ignored():
+    """Old/unknown config keys should not crash from_dict."""
+    cfg = AppConfig.from_dict({
+        "ai_provider": "anthropic",
+        "future_field_we_dont_know_about": "value",
+    })
+    assert cfg.ai_provider == "anthropic"
+
+
+def test_default_provider_is_anthropic():
+    """Sanity check: the default cloud provider hasn't drifted."""
+    cfg = AppConfig()
+    assert cfg.ai_provider == "anthropic"
+    assert cfg.ai_model == "haiku"
+
+
+def test_validate_rejects_unknown_provider():
+    cfg = AppConfig(ai_provider="not-a-real-provider")
+    ok, err = validate_config(cfg)
+    assert not ok
+    assert "ai_provider" in err.lower()
+
+
+def test_validate_rejects_invalid_anthropic_model():
+    cfg = AppConfig(ai_provider="anthropic", ai_model="not-a-real-model",
+                    anthropic_api_key="sk-ant-test")
+    ok, err = validate_config(cfg)
+    assert not ok
+    assert "ai_model" in err.lower()
+
+
+def test_validate_accepts_valid_anthropic_config():
+    cfg = AppConfig(ai_provider="anthropic", ai_model="haiku",
+                    anthropic_api_key="sk-ant-test")
+    ok, err = validate_config(cfg)
+    assert ok, f"expected valid, got error: {err}"
+
+
+def test_validate_none_provider_is_always_valid():
+    """ai_provider='none' should validate without any keys."""
+    cfg = AppConfig(ai_provider="none")
+    ok, err = validate_config(cfg)
+    assert ok, err
+
+
+def test_to_safe_dict_redacts_keys():
+    """API keys must be redacted in the safe dict (used for logging)."""
+    cfg = AppConfig(
+        anthropic_api_key="sk-ant-supersecretkey12345",
+        openai_api_key="sk-openaikey9876543210",
+        openrouter_api_key="orkey1234567890",
+    )
+    safe = cfg.to_safe_dict()
+    assert "supersecretkey" not in safe["anthropic_api_key"]
+    assert "openaikey" not in safe["openai_api_key"]
+    assert "1234567890" not in safe["openrouter_api_key"]

--- a/tests/test_paths_and_fallbacks.py
+++ b/tests/test_paths_and_fallbacks.py
@@ -1,0 +1,82 @@
+"""Tests for path handling (expanduser, parents=True) and ollama_model fallback.
+
+These cover behaviour added across mathstuf #7 (expanduser), jmalobicky's
+parents=True, and eduspano's empty-ollama-model fallback.
+"""
+from pathlib import Path
+
+from meeting_notes.note_maker import NoteMaker
+from meeting_notes.recorder import AudioRecorder
+
+
+def test_note_maker_expands_user(tmp_path, monkeypatch):
+    """NoteMaker should expand ~ in directory paths (mathstuf #7)."""
+    # Point HOME at a temp dir so ~ resolves somewhere safe
+    monkeypatch.setenv("HOME", str(tmp_path))
+    nm = NoteMaker(
+        output_dir="~/notes",
+        transcripts_dir="~/transcripts",
+        ai_provider="none",
+    )
+    assert nm.output_dir == tmp_path / "notes"
+    assert nm.transcripts_dir == tmp_path / "transcripts"
+    assert nm.output_dir.is_dir()
+    assert nm.transcripts_dir.is_dir()
+
+
+def test_note_maker_creates_nested_dirs(tmp_path):
+    """parents=True (jmalobicky) lets users configure deep nested paths."""
+    deep_out = tmp_path / "a" / "b" / "c" / "out"
+    deep_tx = tmp_path / "a" / "b" / "c" / "tx"
+    nm = NoteMaker(
+        output_dir=str(deep_out),
+        transcripts_dir=str(deep_tx),
+        ai_provider="none",
+    )
+    assert nm.output_dir.is_dir()
+    assert nm.transcripts_dir.is_dir()
+
+
+def test_recorder_creates_nested_dirs(tmp_path):
+    """AudioRecorder should also handle nested output dirs."""
+    deep = tmp_path / "x" / "y" / "z" / "recordings"
+    AudioRecorder(output_dir=str(deep))
+    assert deep.is_dir()
+
+
+def test_recorder_expands_user(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    r = AudioRecorder(output_dir="~/recordings")
+    assert r.output_dir == tmp_path / "recordings"
+    assert r.output_dir.is_dir()
+
+
+def test_empty_ollama_model_falls_back():
+    """eduspano's fix: empty string must not pass through dict.get default.
+
+    This is the regression test for the actual bug — `dict.get(key, default)`
+    returns the empty string when the key is present-but-empty, not the default.
+    The fix uses `or` to also catch falsy values.
+    """
+    cfg = {"ollama_model": ""}
+
+    # The old, buggy pattern:
+    buggy = cfg.get("ollama_model", "llama3.2:3b")
+    assert buggy == "", "this empty string is exactly what caused 'model is required'"
+
+    # The fixed pattern:
+    fixed = cfg.get("ollama_model") or "llama3.2:3b"
+    assert fixed == "llama3.2:3b"
+
+
+def test_missing_ollama_model_falls_back():
+    """When the key is genuinely missing, both patterns work — sanity check."""
+    cfg = {}
+    assert (cfg.get("ollama_model") or "llama3.2:3b") == "llama3.2:3b"
+    assert cfg.get("ollama_model", "llama3.2:3b") == "llama3.2:3b"
+
+
+def test_set_ollama_model_passes_through():
+    """A real model name should not be replaced by the fallback."""
+    cfg = {"ollama_model": "qwen2.5:7b"}
+    assert (cfg.get("ollama_model") or "llama3.2:3b") == "qwen2.5:7b"

--- a/tests/test_recording_retention.py
+++ b/tests/test_recording_retention.py
@@ -1,0 +1,125 @@
+"""Tests for the recording retention cleanup logic.
+
+We test the underlying datetime-comparison logic rather than the
+MeetingNotesApp method directly, because the latter requires a full
+Textual app instance. The logic is small enough that the duplication
+is tolerable, and these tests document the expected behaviour clearly.
+
+If the implementation in app.py changes, this file is the spec.
+"""
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+def _cleanup(recordings_dir: Path, retention_days: int) -> list[str]:
+    """Mirror of MeetingNotesApp._cleanup_old_recordings, returns deleted names."""
+    if retention_days <= 0:
+        return []
+    if not recordings_dir.is_dir():
+        return []
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    removed = []
+    for wav in recordings_dir.glob("*.wav"):
+        if datetime.fromtimestamp(wav.stat().st_mtime) < cutoff:
+            wav.unlink()
+            removed.append(wav.name)
+    return removed
+
+
+def _set_age(path: Path, days_ago: int) -> None:
+    ts = (datetime.now() - timedelta(days=days_ago)).timestamp()
+    os.utime(path, (ts, ts))
+
+
+def test_deletes_old_wav_files(tmp_path):
+    old = tmp_path / "old.wav"
+    new = tmp_path / "new.wav"
+    old.write_bytes(b"x")
+    new.write_bytes(b"x")
+    _set_age(old, 60)
+    _set_age(new, 5)
+
+    removed = _cleanup(tmp_path, retention_days=30)
+
+    assert removed == ["old.wav"]
+    assert not old.exists()
+    assert new.exists()
+
+
+def test_retention_zero_disables_cleanup(tmp_path):
+    old = tmp_path / "ancient.wav"
+    old.write_bytes(b"x")
+    _set_age(old, 365)
+
+    removed = _cleanup(tmp_path, retention_days=0)
+
+    assert removed == []
+    assert old.exists(), "retention=0 must not delete anything"
+
+
+def test_negative_retention_is_treated_as_disabled(tmp_path):
+    """Defensive: negative values shouldn't delete everything."""
+    old = tmp_path / "ancient.wav"
+    old.write_bytes(b"x")
+    _set_age(old, 365)
+
+    removed = _cleanup(tmp_path, retention_days=-1)
+
+    assert removed == []
+    assert old.exists()
+
+
+def test_missing_directory_is_noop(tmp_path):
+    """If the recordings dir doesn't exist, cleanup must not crash."""
+    nonexistent = tmp_path / "does-not-exist"
+    removed = _cleanup(nonexistent, retention_days=30)
+    assert removed == []
+
+
+def test_only_wav_files_are_considered(tmp_path):
+    """Other extensions should not be touched even if very old."""
+    old_wav = tmp_path / "old.wav"
+    old_txt = tmp_path / "old.txt"
+    old_md = tmp_path / "old.md"
+    for f in (old_wav, old_txt, old_md):
+        f.write_bytes(b"x")
+        _set_age(f, 60)
+
+    removed = _cleanup(tmp_path, retention_days=30)
+
+    assert removed == ["old.wav"]
+    assert not old_wav.exists()
+    assert old_txt.exists()
+    assert old_md.exists()
+
+
+def test_files_at_exactly_the_boundary_are_kept(tmp_path):
+    """A file mtime'd exactly at the cutoff should NOT be deleted (strict <)."""
+    edge = tmp_path / "edge.wav"
+    edge.write_bytes(b"x")
+    _set_age(edge, 5)  # comfortably newer than 30-day cutoff
+    removed = _cleanup(tmp_path, retention_days=30)
+    assert removed == []
+    assert edge.exists()
+
+
+@pytest.mark.parametrize("days_old,retention,should_delete", [
+    (1, 30, False),
+    (29, 30, False),
+    (31, 30, True),
+    (60, 30, True),
+    # A file aged exactly N days vs N-day retention races the cutoff
+    # because _set_age runs microseconds before _cleanup samples now().
+    # Skip the exact-equal case and just test clearly above/below.
+    (5, 1, True),
+    (0, 1, False),
+])
+def test_retention_boundary_table(tmp_path, days_old, retention, should_delete):
+    f = tmp_path / "x.wav"
+    f.write_bytes(b"x")
+    _set_age(f, days_old)
+    _cleanup(tmp_path, retention_days=retention)
+    assert f.exists() != should_delete

--- a/tests/test_summarizers.py
+++ b/tests/test_summarizers.py
@@ -1,0 +1,67 @@
+"""Tests for the model registries in summarizer classes.
+
+These tests don't make network calls — they just check that the model IDs
+configured in MODELS dicts haven't drifted from what the providers actually
+accept. If a provider deprecates a model, you'd update both the constant
+here and the source.
+"""
+from meeting_notes.ai_summarizer import (
+    AnthropicSummarizer,
+    OpenAISummarizer,
+    OpenRouterSummarizer,
+)
+
+
+def test_anthropic_haiku_is_current_4_5():
+    """eduspano/jmalobicky bumped Haiku from 3.5 to 4.5."""
+    haiku = AnthropicSummarizer.MODELS["haiku"]
+    assert haiku["id"] == "claude-haiku-4-5-20251001"
+    assert "4.5" in haiku["name"]
+
+
+def test_anthropic_sonnet_is_current_4_6():
+    """eduspano bumped Sonnet to 4.6."""
+    sonnet = AnthropicSummarizer.MODELS["sonnet"]
+    assert sonnet["id"] == "claude-sonnet-4-6"
+    assert "4.6" in sonnet["name"]
+
+
+def test_anthropic_no_deprecated_3_5_ids_remain():
+    """Guard against accidental revert to deprecated 3.5 model IDs."""
+    for tier, info in AnthropicSummarizer.MODELS.items():
+        assert "3-5" not in info["id"], f"{tier} still references deprecated 3.5 model"
+        assert "3.5" not in info["name"], f"{tier} still labelled as 3.5"
+
+
+def test_anthropic_models_have_required_fields():
+    for tier, info in AnthropicSummarizer.MODELS.items():
+        for field in ("id", "name", "cost_per_1k_input", "cost_per_1k_output"):
+            assert field in info, f"Anthropic {tier} missing {field}"
+        assert isinstance(info["cost_per_1k_input"], (int, float))
+
+
+def test_openai_models_have_required_fields():
+    for tier, info in OpenAISummarizer.MODELS.items():
+        for field in ("id", "name", "cost_per_1k_input", "cost_per_1k_output"):
+            assert field in info, f"OpenAI {tier} missing {field}"
+
+
+def test_openrouter_models_have_required_fields():
+    for tier, info in OpenRouterSummarizer.MODELS.items():
+        for field in ("id", "name"):
+            assert field in info, f"OpenRouter {tier} missing {field}"
+
+
+def test_anthropic_summarizer_requires_api_key(monkeypatch):
+    """Without an API key (and no env var), construction should fail clearly."""
+    import pytest
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key"):
+        AnthropicSummarizer(api_key=None, model="haiku")
+
+
+def test_anthropic_summarizer_rejects_unknown_model():
+    """Unknown model tier should not be silently accepted."""
+    import pytest
+    with pytest.raises((KeyError, ValueError)):
+        AnthropicSummarizer(api_key="sk-ant-test", model="not-a-tier")

--- a/tests/test_textual_smoke.py
+++ b/tests/test_textual_smoke.py
@@ -1,0 +1,99 @@
+"""Headless Textual smoke tests using App.run_test().
+
+These are intentionally minimal — full UI flows are slow and brittle.
+We just want to catch:
+  - The app actually starts without raising
+  - The settings screen opens
+  - Switching providers in settings doesn't crash with the duplicate-ID
+    error (the bug PR #9 fixed; this is a regression guard)
+
+These tests transitively import whisper (via meeting_notes.app →
+meeting_notes.transcriber), which pulls in torch. CI deliberately skips
+this file to keep install time fast — see .github/workflows/ci.yml. To
+run locally:
+
+    pip install -e ".[all,dev]"
+    pytest tests/test_textual_smoke.py
+"""
+import pytest
+
+# Skip the entire module if the heavy deps (whisper / textual) aren't
+# installed. Avoids confusing import errors for contributors who only
+# installed the lightweight test deps.
+pytest.importorskip("whisper", reason="run `pip install -e .[all,dev]` to enable Textual smoke tests")
+pytest.importorskip("textual", reason="run `pip install -e .[all,dev]` to enable Textual smoke tests")
+
+from meeting_notes.app import MeetingNotesApp  # noqa: E402  (deliberate import-after-skip)
+
+
+@pytest.mark.asyncio
+async def test_app_starts_and_exits_cleanly(tmp_path, monkeypatch):
+    """The app should mount cleanly in headless mode and respond to ctrl+c-equivalent."""
+    # Sandbox config & data dirs so the test doesn't touch real ones
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    app = MeetingNotesApp()
+    async with app.run_test() as pilot:
+        # Just let the app stabilise. If anything raises during mount,
+        # we'd see it here.
+        await pilot.pause()
+        assert app.is_running
+        # Quit cleanly
+        app.exit()
+
+
+@pytest.mark.asyncio
+async def test_settings_screen_opens(tmp_path, monkeypatch):
+    """Pressing ',' should open the settings screen without error."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    app = MeetingNotesApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press(",")
+        await pilot.pause()
+        # SettingsScreen should now be on the screen stack.
+        # (We don't import it for an isinstance check — its exact import
+        # path isn't load-bearing; just confirm the stack changed.)
+        assert len(app.screen_stack) >= 2, "settings screen should have been pushed"
+        app.exit()
+
+
+@pytest.mark.asyncio
+async def test_switching_providers_does_not_duplicate_widget_ids(tmp_path, monkeypatch):
+    """Regression test for issue #11 / PR #9.
+
+    Switching AI providers used to crash with `DuplicateIds: provider-openai`
+    because remove_children() wasn't awaited before mount(). This test
+    rapidly clicks between providers and asserts no exception.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    app = MeetingNotesApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press(",")  # open settings
+        await pilot.pause()
+
+        # Click each provider button in turn.  If remove_children isn't
+        # awaited, the second mount of any provider button will raise
+        # DuplicateIds.
+        provider_ids = ["provider-openai", "provider-anthropic",
+                        "provider-openrouter", "provider-anthropic"]
+        for pid in provider_ids:
+            try:
+                await pilot.click(f"#{pid}")
+                await pilot.pause()
+            except Exception as e:
+                # Surface DuplicateIds clearly if it ever comes back
+                if "Duplicate" in type(e).__name__ or "already exists" in str(e):
+                    pytest.fail(f"PR #9 regressed — DuplicateIds when clicking {pid}: {e}")
+                # Other failures (e.g. button not found because layout
+                # changed) shouldn't fail this specific regression test
+                # — re-raise to fail loudly so the test gets updated.
+                raise
+
+        app.exit()


### PR DESCRIPTION
## Summary

Three things in one PR (kept together because they're tightly related — the tests cover the bug fixes, and CI runs the tests):

1. **Fork-derived bug fixes & UX wins** — sourced from review of the `jmalobicky` and `eduspano` forks of this repo
2. **Test suite** — new `tests/` directory with pytest + ruff config covering this PR's changes plus the recently-merged community PRs (#4–#9)
3. **CI** — GitHub Actions workflow running ruff + pytest on every PR

## Bug fixes & UX (commit 1)

**Bug fixes:**
- **tqdm lock pre-warm** *(from eduspano)* — belt-and-braces alongside the existing `resource_tracker.ensure_running()` call from PR #6, against the same Python 3.14 `fork_exec`/`fds_to_keep` crash. tqdm lazily creates an `RLock` on first use; eduspano's diagnosis pinpoints tqdm specifically as the trigger that the existing fix may not fully cover. Both are cheap; running them together costs nothing.
- **Anthropic model IDs** *(from eduspano)* — `claude-3-5-haiku-20241022` and `claude-3-5-sonnet-20241022` were starting to return `404 not_found_error`. Updated to `claude-haiku-4-5-20251001` and `claude-sonnet-4-6`. UI labels updated to match.
- **Empty `ollama_model` fallback** *(from eduspano)* — `dict.get("ollama_model", "llama3.2:3b")` only fills the default when the key is missing; an empty string passes through and produces `ollama run "" <prompt>` → `Error: model is required`. Fixed in two places in `settings.py` plus a defensive belt at the `OllamaSummarizer` call site in `note_maker.py`.
- **Transcript-of-deleted-note guard** *(from jmalobicky)* — viewing a transcript whose underlying note file had been deleted crashed with `FileNotFoundError`. Now shows a notification and returns cleanly.
- **`parents=True` on user-facing `mkdir`** *(from jmalobicky)* — configured paths like `~/Documents/notes/meetings/` now work even when intermediate directories don't exist yet. Applied in `app.py` (notes_dir, twice), `note_maker.py` (output_dir, transcripts_dir), and `recorder.py` (output_dir).

**UX:**
- **Esc unfocuses notes textarea too** *(from jmalobicky)* — previously only unfocused the title input.
- **`s` / `x` keys work in recording view without input focus** *(from jmalobicky)* — global stop/cancel shortcuts no longer require tabbing away from inputs first.
- **`recording_retention_days: int = 30`** *(from jmalobicky)* — new config field; auto-deletes `.wav` files older than this on app startup. Set to 0 (or any non-positive int) to disable. Errors are logged but never raised.

## Tests (commit 2)

New `tests/` directory (un-gitignored from the previous "outdated" entry). 41 tests, ~5s full / 0.08s lightweight subset:

| File | Tests | Coverage |
|---|---|---|
| `test_config.py` | 11 | AppConfig defaults, dict roundtrip, validation, key redaction |
| `test_summarizers.py` | 8 | Model registry sanity, no deprecated 3.5 IDs, required fields |
| `test_paths_and_fallbacks.py` | 7 | expanduser + parents=True, empty-ollama_model `or` fallback regression |
| `test_recording_retention.py` | 12 | Behavioural spec for retention cleanup, parametrized boundary table |
| `test_textual_smoke.py` | 3 | Headless `App.run_test()`: app starts, settings opens, **provider switching does NOT raise DuplicateIds** (regression guard for #11 / #9) |

The Textual smoke tests use `pytest.importorskip` so they skip cleanly when only the lightweight deps are installed.

Adds `[project.optional-dependencies] dev = [pytest, pytest-asyncio, ruff]` plus minimal pytest/ruff config in `pyproject.toml`. Ruff config is intentionally conservative (`E9 + F + B` minus several noisy rules) — catches real bugs without forcing a wide style cleanup of pre-existing code.

## CI (commit 3)

`.github/workflows/ci.yml` — single job, Python 3.12, ubuntu-latest, runs on `pull_request` and `push` to `main` with concurrency cancellation.

Deliberately installs only the lightweight test deps — NOT the `[all]` extra. Pulling `openai-whisper` transitively installs torch (~1GB) which would dominate CI time for no benefit; the fast tests don't need it. Test files are explicitly listed in the workflow so a future heavy-dep test file can be added without breaking CI.

The Textual smoke tests are kept as a local-only regression guard (run via `pytest tests/test_textual_smoke.py` after `pip install -e ".[all,dev]"`). Documented in the new README "Running tests" section.

## Verification

- `pytest`: 41 passed locally (38 fast in 0.08s + 3 Textual in ~5s)
- `ruff check meeting_notes/ tests/`: clean
- `python -m build`: sdist + wheel build cleanly with the updated pyproject

## Notes for review

- The 4 commits are individually reviewable; the bug fix commit (`2af8eda`) is the load-bearing one. Tests + CI can be evaluated independently.
- Credit to `jmalobicky` and `eduspano` for the original work — their forks don't have PRs open against this repo, so the changes are mentioned by name in commit messages and this description rather than co-author tags.
- Pre-existing ruff issues (B904 raise-from, F541 empty f-strings, etc.) are explicitly ignored in `[tool.ruff.lint]` to avoid this PR ballooning into a style cleanup. Easy to enable later.