### PR TITLE
Setup | Create cloud config directory before writing

### DIFF
--- a/setup_cloud.sh
+++ b/setup_cloud.sh
@@ -92,6 +92,7 @@ echo "Updating config..."
 
 # Update config file
 CONFIG_FILE="$HOME/.config/meeting-notes/config.yaml"
+mkdir -p "$(dirname "$CONFIG_FILE")"
 
 # Check if config already exists and warn user
 if [ -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Changes

Create the meeting-notes config directory before writing `config.yaml`, so cloud setup works on a fresh installation.

## Testing

- Run `bash -n setup_cloud.sh`
- Run cloud setup without an existing `~/.config/meeting-notes` directory and confirm it creates the config file